### PR TITLE
Delete Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM pangeo/pangeo-notebook:2021.07.17
-
-COPY requirements.txt /tmp/requirements.txt
-
-RUN pip install --no-cache -r /tmp/requirements.txt


### PR DESCRIPTION
This stops bringing in default packages from the pangeo images,
and directly uses just a `requirements.txt` file to get the
repo2docker behavior documented [here](https://repo2docker.readthedocs.io/en/latest/config_files.html)